### PR TITLE
Accept date on typing in input

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1622,13 +1622,8 @@
 
             if (event.keyCode === 13 && event.target.getAttribute('name') === 'daterangepicker_start') {
                 // Prevent the calendar from being updated twice on Chrome/Firefox/Edge
-<<<<<<< HEAD
                 event.preventDefault();
                 this.formInputsChanged(event);
-=======
-                e.preventDefault();
-                this.formInputsChanged(e);
->>>>>>> master
             }
 
             if (event.target.getAttribute('name') === 'daterangepicker_end') {

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,4 +1,4 @@
-/**
+*
 * @version: 2.1.27
 * @author: Dan Grossman http://www.dangrossman.info/
 * @copyright: Copyright (c) 2012-2017 Dan Grossman. All rights reserved.
@@ -1589,16 +1589,67 @@
 
         },
 
-        formInputsKeydown: function(e) {
+        debounceAction: function (action, wait) {
+
+            var timeout;
+
+            return function() {
+                var context = this, args = arguments;
+                var later = function () {
+                    timeout = null;
+                    action.apply(context, args);
+                };
+                clearTimeout(timeout);
+                timeout = setTimeout(later, wait);
+            };
+
+        },
+
+        handleInputDateChange: function (dateValue, dateType) {
+
+            var date = moment(dateValue, this.locale.format);
+
+            if (date.isValid()) {
+
+                if (dateType === 'end') {
+                    this.setEndDate(date);
+                }
+
+                if (dateType === 'start') {
+                    this.setStartDate(date);
+                }
+
+                this.updateView();
+            }
+
+        },
+
+        formInputsKeydown: function(event) {
             // This function ensures that if the 'enter' key was pressed in the input, then the calendars
             // are updated with the startDate and endDate.
             // This behaviour is automatic in Chrome/Firefox/Edge but not in IE 11 hence why this exists.
             // Other browsers and versions of IE are untested and the behaviour is unknown.
-            if (e.keyCode === 13) {
+
+            var manager = this
+
+            if (event.keyCode === 13) {
                 // Prevent the calendar from being updated twice on Chrome/Firefox/Edge
-                e.preventDefault(); 
-                this.formInputsChanged(e);
+                event.preventDefault();
+                this.formInputsChanged(event);
             }
+
+            if (event.target.getAttribute('name') === 'daterangepicker_end') {
+
+                var allowedInactivityTime = 500;
+                var debouncedInputChangeHandler = this.debounceAction(
+                    function () { return manager.handleInputDateChange(event.target.value, 'end') }, allowedInactivityTime
+                )
+
+                setTimeout(function(){
+                    debouncedInputChangeHandler();
+                }.bind(this), 100)
+            }
+
         },
 
 

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -1,4 +1,4 @@
-*
+/**
 * @version: 2.1.27
 * @author: Dan Grossman http://www.dangrossman.info/
 * @copyright: Copyright (c) 2012-2017 Dan Grossman. All rights reserved.
@@ -1032,9 +1032,11 @@
 
         updateFormInputs: function() {
 
+            //comment out this behaviour according to requested change in AIT-2454
+
             //ignore mouse movements while an above-calendar text input has focus
-            if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
-                return;
+            // if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
+            //     return;
 
             this.container.find('input[name=daterangepicker_start]').val(this.startDate.format(this.locale.format));
             if (this.endDate)
@@ -1632,7 +1634,7 @@
 
             var manager = this
 
-            if (event.keyCode === 13) {
+            if (event.keyCode === 13 && event.target.getAttribute('name') === 'daterangepicker_start') {
                 // Prevent the calendar from being updated twice on Chrome/Firefox/Edge
                 event.preventDefault();
                 this.formInputsChanged(event);


### PR DESCRIPTION
AIT-2454 -> update selected date when typing in end date input automatically if more then 0.5s passed between keystrokes, after submitting end date with enter when field is still focused and hover over calendar on mouse leave this area date is reset properly to saved one